### PR TITLE
Fix Incorrect Keyword Argument in create_order_rest_json Function

### DIFF
--- a/aevo.py
+++ b/aevo.py
@@ -207,7 +207,7 @@ class AevoClient:
             is_buy,
             limit_price,
             quantity,
-            decimals=1,
+            price_decimals=1,
             post_only=False,
         )
 


### PR DESCRIPTION
## Overview
Fixed an issue where an incorrect keyword argument was used in the `create_order_rest_json` function, which led to a TypeError. This error was encountered in the `rest_create_market_order` method of the `AevoClient` class.

## Changes
- Changed the keyword argument from `decimals` to `price_decimals` in the `create_order_rest_json` function call.

## Impact
This change resolves the TypeError that was occurring during the invocation of `create_order_rest_json` within `rest_create_market_order`. The function now operates as expected without any argument-related errors.

## Testing
- Confirmed that the TypeError during the function call is resolved.

## Error Details

```
  File "/usr/local/lib/python3.9/site-packages/aevo.py", line 205, in rest_create_market_order
    data, order_id = self.create_order_rest_json(
TypeError: create_order_rest_json() got an unexpected keyword argument 'decimals'
```
