### PR TITLE
fix bug in market order

### DIFF
--- a/aevo.py
+++ b/aevo.py
@@ -207,7 +207,6 @@ class AevoClient:
             is_buy,
             limit_price,
             quantity,
-            decimals=1,
             post_only=False,
         )
 


### PR DESCRIPTION
because there's no `decimal` parameter in `create_order_reset_json`